### PR TITLE
feat: add per-page note window

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -8,6 +8,7 @@ import {
 import { getString, initLocale } from "./utils/locale";
 import { registerPrefsScripts } from "./modules/preferenceScript";
 import { createZToolkit } from "./utils/ztoolkit";
+import NoteSync from "./modules/noteSync";
 
 async function onStartup() {
   await Promise.all([
@@ -124,9 +125,10 @@ async function onNotify(
     type == "tab" &&
     extraData[ids[0]].type == "reader"
   ) {
-    BasicExampleFactory.exampleNotifierCallback();
-  } else {
-    return;
+    const reader = (Zotero as any).Reader.getByTabID(String(ids[0]));
+    if (reader) {
+      NoteSync.openForReader(reader);
+    }
   }
 }
 

--- a/src/modules/noteSync.ts
+++ b/src/modules/noteSync.ts
@@ -1,0 +1,56 @@
+import { DialogHelper } from "zotero-plugin-toolkit";
+
+interface NoteState {
+  notes: Record<number, string>;
+  page: number;
+}
+
+export default class NoteSync {
+  static openForReader(reader: any): void {
+    if (!addon.data.dialog || addon.data.dialog.window?.closed) {
+      addon.data.dialog = new DialogHelper(1, 1)
+        .addCell(0, 0, {
+          tag: "textarea",
+          namespace: "html",
+          id: "page-note",
+          attributes: {
+            style: "width:100%;height:100%;",
+          },
+        })
+        .addButton("Close", "close");
+      addon.data.dialog.open("Page Notes", {
+        width: 300,
+        height: 400,
+        resizable: true,
+        centerscreen: true,
+      });
+    }
+    this.bindReader(reader);
+  }
+
+  private static bindReader(reader: any): void {
+    if (!reader._noteSync) {
+      const state: NoteState = { notes: {}, page: 1 };
+      reader._noteSync = state;
+      const eventBus = reader?._iframeWindow?.PDFViewerApplication?.eventBus;
+      eventBus?.on("pagechanging", (e: any) => {
+        const textarea = addon.data.dialog?.window?.document.getElementById(
+          "page-note",
+        ) as HTMLTextAreaElement | null;
+        if (!textarea) return;
+        const prev = state.page;
+        state.notes[prev] = textarea.value;
+        const newPage = e.pageNumber;
+        textarea.value = state.notes[newPage] || "";
+        state.page = newPage;
+      });
+    }
+    const textarea = addon.data.dialog?.window?.document.getElementById(
+      "page-note",
+    ) as HTMLTextAreaElement | null;
+    if (textarea) {
+      const curPage: number = reader._noteSync.page || 1;
+      textarea.value = reader._noteSync.notes[curPage] || "";
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- open note window when PDF reader tab is selected
- sync note content with current PDF page

## Testing
- `npm run lint:check`
- `npm test` *(fails: AggregateError ENETUNREACH)*


------
https://chatgpt.com/codex/tasks/task_e_689afe6597b8832986d5458d49166dcd