### PR TITLE
Fix locale branch lookup

### DIFF
--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -73,12 +73,8 @@ function _getString(
     return localStringWithPrefix;
   }
   if (branch && pattern.attributes) {
-    for (const attr of pattern.attributes) {
-      if (attr.name === branch) {
-        return attr.value;
-      }
-    }
-    return pattern.attributes[branch] || localStringWithPrefix;
+    const attr = pattern.attributes.find((a) => a.name === branch);
+    return attr ? attr.value : pattern.value || localStringWithPrefix;
   } else {
     return pattern.value || localStringWithPrefix;
   }


### PR DESCRIPTION
## Summary
- handle missing locale attribute gracefully

## Testing
- `npm test` *(fails: fetch failed)*
- `npm run lint:check`


------
https://chatgpt.com/codex/tasks/task_e_689afdc61e248329b0afd0a8ccd5bbf0